### PR TITLE
Update version to 1.4.0-alpha.147

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@1.8.0
+ - @yext/search-core@1.9.0-alpha.188
 
 This package contains the following license and notice below:
 
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@1.3.0
+ - @yext/search-headless@1.4.0-alpha.120
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^1.3.0",
+        "@yext/search-headless": "^1.4.0-alpha.120",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4244,9 +4244,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.8.0.tgz",
-      "integrity": "sha512-t7rg9JZ9K6pIt2nBZ1O+xhzG+zMFVAu9Vgwh8cTey8NA7878cQ6n6BauTwimVdbrNGHq3D2dPUno/kVtKAgPiQ==",
+      "version": "1.9.0-alpha.188",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0-alpha.188.tgz",
+      "integrity": "sha512-g1agribhx3/B0KN8zWcsL9BL+3/v+qxTKQ2jahP4lpMmMSAxeO/rZUcXolNP47yoe37nDRiRmWEpM1ORTgrcOw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -4256,12 +4256,12 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.3.0.tgz",
-      "integrity": "sha512-T5Gvb7MObWTtBPiTIs2WuZgxF44Ro89qiGabl2S1PcN4eQBV3nVVVgFNN1cqCN9K2m4gcm1U9ctAbJyme83vRA==",
+      "version": "1.4.0-alpha.120",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0-alpha.120.tgz",
+      "integrity": "sha512-RLVNQ+F47GYtVkctsSSm/xQ3yAy4kuGHB4h3lsCg4B2cfu2NmXXhIQTLbBfIIsKkZJdLQA2cGcRQUJKYAZCqrA==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.8.0",
+        "@yext/search-core": "^1.9.0-alpha.188",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
@@ -15706,21 +15706,21 @@
       }
     },
     "@yext/search-core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.8.0.tgz",
-      "integrity": "sha512-t7rg9JZ9K6pIt2nBZ1O+xhzG+zMFVAu9Vgwh8cTey8NA7878cQ6n6BauTwimVdbrNGHq3D2dPUno/kVtKAgPiQ==",
+      "version": "1.9.0-alpha.188",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0-alpha.188.tgz",
+      "integrity": "sha512-g1agribhx3/B0KN8zWcsL9BL+3/v+qxTKQ2jahP4lpMmMSAxeO/rZUcXolNP47yoe37nDRiRmWEpM1ORTgrcOw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
       }
     },
     "@yext/search-headless": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.3.0.tgz",
-      "integrity": "sha512-T5Gvb7MObWTtBPiTIs2WuZgxF44Ro89qiGabl2S1PcN4eQBV3nVVVgFNN1cqCN9K2m4gcm1U9ctAbJyme83vRA==",
+      "version": "1.4.0-alpha.120",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0-alpha.120.tgz",
+      "integrity": "sha512-RLVNQ+F47GYtVkctsSSm/xQ3yAy4kuGHB4h3lsCg4B2cfu2NmXXhIQTLbBfIIsKkZJdLQA2cGcRQUJKYAZCqrA==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.8.0",
+        "@yext/search-core": "^1.9.0-alpha.188",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.147",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "1.3.0",
+      "version": "1.4.0-alpha.147",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@yext/search-headless": "^1.4.0-alpha.120",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^1.3.0",
+    "@yext/search-headless": "^1.4.0-alpha.120",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha.147",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./lib/esm/src/index.js",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Bump the Headless version to 1.4.0-beta.120 to incorporate the changes in Core to make `Result` a generic.

J=SLAP-2232
TEST=none