### PR TITLE
Update Headless version

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@1.9.0
+ - @yext/search-core@2.0.0-alpha.204
 
 This package contains the following license and notice below:
 
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@1.4.0
+ - @yext/search-headless@2.0.0-alpha.130
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^1.4.0",
+        "@yext/search-headless": "^2.0.0-alpha.130",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4244,9 +4244,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0.tgz",
-      "integrity": "sha512-HiAF+8D00ZYl3CbC7E6nc4cNWpJgm93WFARHhSzMeN9Ht8XVqdLKkNZN8vCpg2K2jht2IYhCIuJfpW80kDD62w==",
+      "version": "2.0.0-alpha.204",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
+      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -4256,12 +4256,12 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0.tgz",
-      "integrity": "sha512-7lEYYw2+rpP3cFn2ecHbEEPYX1fHd6aYe0FBSqXffXpbBTShuDjsfq4fyvehIu8PSdJsWpqA3RedxRC3q5nQWw==",
+      "version": "2.0.0-alpha.130",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
+      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.9.0",
+        "@yext/search-core": "^2.0.0-alpha.204",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
@@ -15706,21 +15706,21 @@
       }
     },
     "@yext/search-core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0.tgz",
-      "integrity": "sha512-HiAF+8D00ZYl3CbC7E6nc4cNWpJgm93WFARHhSzMeN9Ht8XVqdLKkNZN8vCpg2K2jht2IYhCIuJfpW80kDD62w==",
+      "version": "2.0.0-alpha.204",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
+      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
       }
     },
     "@yext/search-headless": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0.tgz",
-      "integrity": "sha512-7lEYYw2+rpP3cFn2ecHbEEPYX1fHd6aYe0FBSqXffXpbBTShuDjsfq4fyvehIu8PSdJsWpqA3RedxRC3q5nQWw==",
+      "version": "2.0.0-alpha.130",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
+      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.9.0",
+        "@yext/search-core": "^2.0.0-alpha.204",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^1.4.0",
+    "@yext/search-headless": "^2.0.0-alpha.130",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {

--- a/tests/useSearchState.test.tsx
+++ b/tests/useSearchState.test.tsx
@@ -21,7 +21,7 @@ it('invoke useSearchState outside of SearchHeadlessProvider', () => {
 it('Retrieves state snapshot during server side rendering and hydration process', () => {
   const answers = createAnswersHeadless();
   const mockedOnClick= jest.fn().mockImplementation(() => {
-    answers.setVertical('anotherFakeKey');
+    answers.setVertical('products');
   });
   function Test(): JSX.Element {
     const verticalKey = useSearchState(state => state.vertical.verticalKey);
@@ -39,14 +39,14 @@ it('Retrieves state snapshot during server side rendering and hydration process'
 
   const container = document.body.appendChild(document.createElement('div'));
   container.innerHTML = renderOnServer();
-  userEvent.click(screen.getByText('fakeVerticalKey'));
+  userEvent.click(screen.getByText('people'));
   expect(mockedOnClick).toBeCalledTimes(0);
 
   //attach event listeners to the existing markup
   render(<App />, { container, hydrate: true });
-  userEvent.click(screen.getByText('fakeVerticalKey'));
+  userEvent.click(screen.getByText('people'));
   expect(mockedOnClick).toBeCalledTimes(1);
-  expect(screen.getByText('anotherFakeKey')).toBeDefined();
+  expect(screen.getByText('products')).toBeDefined();
 });
 
 it('does not perform extra renders/listener registrations for nested components', async () => {
@@ -60,7 +60,7 @@ it('does not perform extra renders/listener registrations for nested components'
     }) || [];
     parentStateUpdates.push(results);
     const search = useCallback(() => {
-      actions.setQuery('iphone');
+      actions.setQuery('amani');
       pendingVerticalQuery = actions.executeVerticalQuery();
     }, [actions]);
 
@@ -221,9 +221,9 @@ describe('uses the most recent selector', () => {
 
 function createAnswersHeadless() {
   return provideHeadless({
-    apiKey: 'fake api key',
-    experienceKey: 'fake exp key',
+    apiKey: '2d8c550071a64ea23e263118a2b0680b',
+    experienceKey: 'slanswers',
     locale: 'en',
-    verticalKey: 'fakeVerticalKey'
+    verticalKey: 'people'
   });
 }


### PR DESCRIPTION
Update the Headless version to get the latest static filters changes. Update the `useSearchState` tests because changes to the endpoints in Core were causing them to fail when sending an invalid API key.

J=SLAP-2327
TEST=auto