### PR TITLE
update search-headless to v2 alpha

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@1.9.0
+ - @yext/search-core@2.0.0-alpha.204
 
 This package contains the following license and notice below:
 
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@1.4.0
+ - @yext/search-headless@2.0.0-alpha.130
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^1.4.0",
+        "@yext/search-headless": "^2.0.0-alpha.130",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4244,9 +4244,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0.tgz",
-      "integrity": "sha512-HiAF+8D00ZYl3CbC7E6nc4cNWpJgm93WFARHhSzMeN9Ht8XVqdLKkNZN8vCpg2K2jht2IYhCIuJfpW80kDD62w==",
+      "version": "2.0.0-alpha.204",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
+      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -4256,12 +4256,12 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0.tgz",
-      "integrity": "sha512-7lEYYw2+rpP3cFn2ecHbEEPYX1fHd6aYe0FBSqXffXpbBTShuDjsfq4fyvehIu8PSdJsWpqA3RedxRC3q5nQWw==",
+      "version": "2.0.0-alpha.130",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
+      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.9.0",
+        "@yext/search-core": "^2.0.0-alpha.204",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
@@ -15706,21 +15706,21 @@
       }
     },
     "@yext/search-core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-1.9.0.tgz",
-      "integrity": "sha512-HiAF+8D00ZYl3CbC7E6nc4cNWpJgm93WFARHhSzMeN9Ht8XVqdLKkNZN8vCpg2K2jht2IYhCIuJfpW80kDD62w==",
+      "version": "2.0.0-alpha.204",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.0.0-alpha.204.tgz",
+      "integrity": "sha512-ouV1ZmqrEmwLXBDjxB/Jou3LbkPmHDAKvSyD9E5beO1D+GOmc8BDkGiQ6c9STgYoXH3L58X+NMHiGf3yFNFWgw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
       }
     },
     "@yext/search-headless": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-1.4.0.tgz",
-      "integrity": "sha512-7lEYYw2+rpP3cFn2ecHbEEPYX1fHd6aYe0FBSqXffXpbBTShuDjsfq4fyvehIu8PSdJsWpqA3RedxRC3q5nQWw==",
+      "version": "2.0.0-alpha.130",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.0.0-alpha.130.tgz",
+      "integrity": "sha512-27dxGT4WHNXhhqkD3NKQdw3Qy4NA7rbLWNUGv+kmF80o+WWw1JLmF8hdy9Os5TdRKwioTK9LwaIciyysuQt+dg==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^1.9.0",
+        "@yext/search-core": "^2.0.0-alpha.204",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.151",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "1.4.0",
+      "version": "2.0.0-alpha.151",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@yext/search-headless": "^2.0.0-alpha.130",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "1.4.0",
+  "version": "2.0.0-alpha.151",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./lib/esm/src/index.js",
   "license": "BSD-3-Clause",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^1.4.0",
+    "@yext/search-headless": "^2.0.0-alpha.130",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {

--- a/tests/setup/server.ts
+++ b/tests/setup/server.ts
@@ -5,7 +5,7 @@ import { universalQueryResponse, universalQueryResponseWithFilters } from './res
 
 // Any unhandled requests are dropped and logged as warnings
 const handlers = [
-  rest.get(/answers\/vertical\/query/, (req, res, ctx) => {
+  rest.get(/search\/vertical\/query/, (req, res, ctx) => {
     const input = req.url.searchParams.get('input');
     switch (input) {
       case 'resultsWithNlpFilter':
@@ -18,7 +18,7 @@ const handlers = [
         );
     }
   }),
-  rest.get(/answers\/query/, (req, res, ctx) => {
+  rest.get(/search\/query/, (req, res, ctx) => {
     const input = req.url.searchParams.get('input');
     switch (input) {
       case 'resultsWithFilter':


### PR DESCRIPTION
Had to update the msw mocks to intercept the new search endpoints.

J=None
TEST=manual

unit tests pass again with no errors
before this there would be an "Invalid API Key" error