### PR TITLE
Fix build entry path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.0.0-alpha.157",
+  "version": "2.0.0-alpha.158",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "2.0.0-alpha.157",
+      "version": "2.0.0-alpha.158",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@yext/search-headless": "2.0.0-alpha.136",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.0.0-alpha.157",
+  "version": "2.0.0-alpha.158",
   "description": "The official React UI Bindings layer for Search Headless",
-  "main": "./lib/esm/src/index.js",
+  "main": "./lib/esm/index.js",
   "license": "BSD-3-Clause",
-  "types": "./lib/esm/src/index.d.ts",
+  "types": "./lib/esm/index.d.ts",
   "keywords": [
     "search",
     "react",
@@ -13,8 +13,8 @@
     "yext"
   ],
   "exports": {
-    "import": "./lib/esm/src/index.js",
-    "require": "./lib/commonjs/src/index.js"
+    "import": "./lib/esm/index.js",
+    "require": "./lib/commonjs/index.js"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Update all the entry points in package.json to omit the `src` directory. The removal of `package.json` import [here](https://github.com/yext/search-headless-react/pull/156/files#diff-e08419e5b1bb742eaecd92aeeb58a12baa6250e1f1d28d3a35c3bb0f72aa5224L5) means the src/ is no longer generated in the lib folder.