### PR TITLE
Update `decode-uri-component` to fix vulnerability

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.0.0
+ - @yext/search-core@2.1.0
 
 This package contains the following license and notice below:
 
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.0.0
+ - @yext/search-headless@2.1.0
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5315,9 +5315,10 @@
       "dev": true
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
@@ -16452,7 +16453,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.0",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "dev": true
     },
     "dedent": {


### PR DESCRIPTION
Bump the version of `decode-uri-component` to address a Snyk vulnerability in v0.2.0.

J=none
TEST=none