### PR TITLE
Prepare v2.2.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @yext/slapshot
+* @yext/backfire

--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.3.0-beta.1
+ - @yext/search-core@2.3.0
 
 This package contains the following license and notice below:
 
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.2.1-beta.0
+ - @yext/search-headless@2.3.0
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^2.2.1-beta.0",
+        "@yext/search-headless": "^2.3.0",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4245,9 +4245,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0-beta.1.tgz",
-      "integrity": "sha512-qO8OC88ZftVLVxyylG0CxM/1Jf6xCVpztwDEKnDu/3lKw9Iq/zHZA7E487y1Ja2MraU6WuiMUNFYJpzYRLOcIw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0.tgz",
+      "integrity": "sha512-vSvNXWv9E/6s4oRB1og4zHfRTTEHrmUm2sh95Y1Dn94U2mkjNDGSsshEeamU2UIJO7Ee5oT6K6JDU7XAVOxC4A==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -4257,12 +4257,12 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.2.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.2.1-beta.0.tgz",
-      "integrity": "sha512-90uvmnE2sOTnv23hTDm4y/DkPsWollufdbNRL43c2RZCsh8GAh2IEWVd1nIdz3k1Ac26XS6kUGVCrGh2TlrWRw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.3.0.tgz",
+      "integrity": "sha512-Uh5DVeV99dkaeF6ayuUEkcUbI8wHn/7bz4aHrjtdDyl3F/6GX3cyHbs/BQh1kWCr+t8EJUWVPl5s4jmL3tst/Q==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.3.0-beta.1",
+        "@yext/search-core": "^2.3.0",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
@@ -15710,21 +15710,21 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.3.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0-beta.1.tgz",
-      "integrity": "sha512-qO8OC88ZftVLVxyylG0CxM/1Jf6xCVpztwDEKnDu/3lKw9Iq/zHZA7E487y1Ja2MraU6WuiMUNFYJpzYRLOcIw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.3.0.tgz",
+      "integrity": "sha512-vSvNXWv9E/6s4oRB1og4zHfRTTEHrmUm2sh95Y1Dn94U2mkjNDGSsshEeamU2UIJO7Ee5oT6K6JDU7XAVOxC4A==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
       }
     },
     "@yext/search-headless": {
-      "version": "2.2.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.2.1-beta.0.tgz",
-      "integrity": "sha512-90uvmnE2sOTnv23hTDm4y/DkPsWollufdbNRL43c2RZCsh8GAh2IEWVd1nIdz3k1Ac26XS6kUGVCrGh2TlrWRw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.3.0.tgz",
+      "integrity": "sha512-Uh5DVeV99dkaeF6ayuUEkcUbI8wHn/7bz4aHrjtdDyl3F/6GX3cyHbs/BQh1kWCr+t8EJUWVPl5s4jmL3tst/Q==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.3.0-beta.1",
+        "@yext/search-core": "^2.3.0",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.2.0-beta.0",
+  "version": "2.2.0",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./lib/esm/index.js",
   "license": "BSD-3-Clause",
@@ -32,7 +32,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^2.2.1-beta.0",
+    "@yext/search-headless": "^2.3.0",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Prepare v2.2.0 by bumping the version number, and updating the search-headless dependency