### PR TITLE
update search-headless dependencies version to 2.6.0-beta

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.5.0
+ - @yext/search-core@2.6.0-beta
 
 This package contains the following license and notice below:
 
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.5.0
+ - @yext/search-headless@2.6.0-beta
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.4.0",
+  "version": "2.4.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "2.4.0",
+      "version": "2.4.0-beta",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^2.5.0",
+        "@yext/search-headless": "^2.6.0-beta",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4312,9 +4312,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.5.0.tgz",
-      "integrity": "sha512-fxbrGkV3hNpjCDMAydGTOksGy2vNx59bP874D5QnaFiwxVT75zX+DIWd4yCMiJnctjerqJQdLmFwZy5NWdJTXw==",
+      "version": "2.6.0-beta",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.tgz",
+      "integrity": "sha512-VUGk2cjTtnVol6+qKg/rApefNwSso8Nmuw2NvXSjh3UEarJMwEwWwkGLkTfFnQo+NksNNQq175ysfEx6cgC1Pw==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -4324,12 +4324,12 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.5.0.tgz",
-      "integrity": "sha512-Ii2dDHxaD0sKrmqbmZt3VEWBIk+U2/p7e0LufruoScRUWtOtD1ASh7QBNjR6okGMVqsfdFWrFxQ7x5QRDxLccA==",
+      "version": "2.6.0-beta",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.tgz",
+      "integrity": "sha512-6lUj/pU3rCcytkriPMSzkXsjVbB/ygN32C5jHYGksaB3bC1sH5ddRa6SOsKfkbqPO0wN6pb+aMV/GBf2eOcZyw==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.5.0",
+        "@yext/search-core": "^2.6.0-beta",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
@@ -16215,21 +16215,21 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.5.0.tgz",
-      "integrity": "sha512-fxbrGkV3hNpjCDMAydGTOksGy2vNx59bP874D5QnaFiwxVT75zX+DIWd4yCMiJnctjerqJQdLmFwZy5NWdJTXw==",
+      "version": "2.6.0-beta",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.tgz",
+      "integrity": "sha512-VUGk2cjTtnVol6+qKg/rApefNwSso8Nmuw2NvXSjh3UEarJMwEwWwkGLkTfFnQo+NksNNQq175ysfEx6cgC1Pw==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
       }
     },
     "@yext/search-headless": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.5.0.tgz",
-      "integrity": "sha512-Ii2dDHxaD0sKrmqbmZt3VEWBIk+U2/p7e0LufruoScRUWtOtD1ASh7QBNjR6okGMVqsfdFWrFxQ7x5QRDxLccA==",
+      "version": "2.6.0-beta",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.tgz",
+      "integrity": "sha512-6lUj/pU3rCcytkriPMSzkXsjVbB/ygN32C5jHYGksaB3bC1sH5ddRa6SOsKfkbqPO0wN6pb+aMV/GBf2eOcZyw==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.5.0",
+        "@yext/search-core": "^2.6.0-beta",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.4.0-beta",
+  "version": "2.5.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "2.4.0-beta",
+      "version": "2.5.0-beta",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@yext/search-headless": "^2.6.0-beta",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.4.0-beta",
+  "version": "2.5.0-beta",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.4.0",
+  "version": "2.4.0-beta",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -38,7 +38,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^2.5.0",
+    "@yext/search-headless": "^2.6.0-beta",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
J=CLIP-1226

Update search-core and search-headless versions to 2.6.0-beta which introduce support for Generative Direct Answer