### PR TITLE
update search-headless dependencies version to 2.6.0-beta.2

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.6.0-beta
+ - @yext/search-headless@2.6.0-beta.2
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.5.0-beta",
+  "version": "2.5.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "2.5.0-beta",
+      "version": "2.5.0-beta.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^2.6.0-beta",
+        "@yext/search-headless": "^2.6.0-beta.2",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4324,9 +4324,9 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.tgz",
-      "integrity": "sha512-6lUj/pU3rCcytkriPMSzkXsjVbB/ygN32C5jHYGksaB3bC1sH5ddRa6SOsKfkbqPO0wN6pb+aMV/GBf2eOcZyw==",
+      "version": "2.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.2.tgz",
+      "integrity": "sha512-lz/LCU3yRMrlTdpQxmjw0qxNrVjCkELbnF9ZOpbGPaKOrsNyzgu00uV16ligYS65CAmLZQX/hsfWs8rVLOen2w==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
         "@yext/search-core": "^2.6.0-beta",
@@ -16224,9 +16224,9 @@
       }
     },
     "@yext/search-headless": {
-      "version": "2.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.tgz",
-      "integrity": "sha512-6lUj/pU3rCcytkriPMSzkXsjVbB/ygN32C5jHYGksaB3bC1sH5ddRa6SOsKfkbqPO0wN6pb+aMV/GBf2eOcZyw==",
+      "version": "2.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.2.tgz",
+      "integrity": "sha512-lz/LCU3yRMrlTdpQxmjw0qxNrVjCkELbnF9ZOpbGPaKOrsNyzgu00uV16ligYS65CAmLZQX/hsfWs8rVLOen2w==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
         "@yext/search-core": "^2.6.0-beta",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.5.0-beta",
+  "version": "2.5.0-beta.2",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -38,7 +38,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^2.6.0-beta",
+    "@yext/search-headless": "^2.6.0-beta.2",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
New version clears gda state response on error

J=CLIP-1226
TEST=auto

ran `npm run test`