### PR TITLE
update search-headless dependencies version to 2.6.0-beta.3

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -62,7 +62,7 @@ SOFTWARE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-core@2.6.0-beta
+ - @yext/search-core@2.6.0-beta.2
 
 This package contains the following license and notice below:
 
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.6.0-beta.2
+ - @yext/search-headless@2.6.0-beta.3
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "2.5.0-beta.2",
+      "version": "2.5.0-beta.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^2.6.0-beta.2",
+        "@yext/search-headless": "^2.6.0-beta.3",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4312,9 +4312,9 @@
       }
     },
     "node_modules/@yext/search-core": {
-      "version": "2.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.tgz",
-      "integrity": "sha512-VUGk2cjTtnVol6+qKg/rApefNwSso8Nmuw2NvXSjh3UEarJMwEwWwkGLkTfFnQo+NksNNQq175ysfEx6cgC1Pw==",
+      "version": "2.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.2.tgz",
+      "integrity": "sha512-xXd/9mWqcLV9dIeIUpzAo/JRkyvDuov3MLbqV0ymTEwRpP/HBQeATFnRsJ/C22Ep4vtjkaKhJdo0LriKDIHb5g==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
@@ -4324,12 +4324,12 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.6.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.2.tgz",
-      "integrity": "sha512-lz/LCU3yRMrlTdpQxmjw0qxNrVjCkELbnF9ZOpbGPaKOrsNyzgu00uV16ligYS65CAmLZQX/hsfWs8rVLOen2w==",
+      "version": "2.6.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.3.tgz",
+      "integrity": "sha512-snSEO15Pf92sKuCxVeUjlGy2Tj06S5KkOS3YmToXijG1PhEML121d+4qcsQB+/c4D1I5/o4Mg/RxzLa1ejWKIA==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.6.0-beta",
+        "@yext/search-core": "^2.6.0-beta.2",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }
@@ -16215,21 +16215,21 @@
       }
     },
     "@yext/search-core": {
-      "version": "2.6.0-beta",
-      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.tgz",
-      "integrity": "sha512-VUGk2cjTtnVol6+qKg/rApefNwSso8Nmuw2NvXSjh3UEarJMwEwWwkGLkTfFnQo+NksNNQq175ysfEx6cgC1Pw==",
+      "version": "2.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@yext/search-core/-/search-core-2.6.0-beta.2.tgz",
+      "integrity": "sha512-xXd/9mWqcLV9dIeIUpzAo/JRkyvDuov3MLbqV0ymTEwRpP/HBQeATFnRsJ/C22Ep4vtjkaKhJdo0LriKDIHb5g==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.5"
       }
     },
     "@yext/search-headless": {
-      "version": "2.6.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.2.tgz",
-      "integrity": "sha512-lz/LCU3yRMrlTdpQxmjw0qxNrVjCkELbnF9ZOpbGPaKOrsNyzgu00uV16ligYS65CAmLZQX/hsfWs8rVLOen2w==",
+      "version": "2.6.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.3.tgz",
+      "integrity": "sha512-snSEO15Pf92sKuCxVeUjlGy2Tj06S5KkOS3YmToXijG1PhEML121d+4qcsQB+/c4D1I5/o4Mg/RxzLa1ejWKIA==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
-        "@yext/search-core": "^2.6.0-beta",
+        "@yext/search-core": "^2.6.0-beta.2",
         "js-levenshtein": "^1.1.6",
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.5.0-beta.2",
+  "version": "2.5.0-beta.3",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -38,7 +38,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^2.6.0-beta.2",
+    "@yext/search-headless": "^2.6.0-beta.3",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
New version has `queryDurationMillis` as an optional field of VerticalResults

J=CLIP-1226
TEST=auto

ran `npm run test`