### PR TITLE
update search-headless dependencies version to 2.6.0-beta.4

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -106,7 +106,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/search-headless@2.6.0-beta.3
+ - @yext/search-headless@2.6.0-beta.4
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.5.0-beta.3",
+  "version": "2.5.0-beta.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@yext/search-headless-react",
-      "version": "2.5.0-beta.3",
+      "version": "2.5.0-beta.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@yext/search-headless": "^2.6.0-beta.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.0-beta.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@yext/search-headless": "^2.6.0-beta.3",
+        "@yext/search-headless": "^2.6.0-beta.4",
         "use-sync-external-store": "^1.1.0"
       },
       "devDependencies": {
@@ -4324,9 +4324,9 @@
       }
     },
     "node_modules/@yext/search-headless": {
-      "version": "2.6.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.3.tgz",
-      "integrity": "sha512-snSEO15Pf92sKuCxVeUjlGy2Tj06S5KkOS3YmToXijG1PhEML121d+4qcsQB+/c4D1I5/o4Mg/RxzLa1ejWKIA==",
+      "version": "2.6.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.4.tgz",
+      "integrity": "sha512-jTynNZZnspHdmEtJd165rO2KP0TvLyguwnAKswkYnGbwFoJMkTUyDxEFJ5tyxbL8Lz6oUw6JxomwaFiAuEJ3Xg==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.8.1",
         "@yext/search-core": "^2.6.0-beta.2",
@@ -16224,9 +16224,9 @@
       }
     },
     "@yext/search-headless": {
-      "version": "2.6.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.3.tgz",
-      "integrity": "sha512-snSEO15Pf92sKuCxVeUjlGy2Tj06S5KkOS3YmToXijG1PhEML121d+4qcsQB+/c4D1I5/o4Mg/RxzLa1ejWKIA==",
+      "version": "2.6.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@yext/search-headless/-/search-headless-2.6.0-beta.4.tgz",
+      "integrity": "sha512-jTynNZZnspHdmEtJd165rO2KP0TvLyguwnAKswkYnGbwFoJMkTUyDxEFJ5tyxbL8Lz6oUw6JxomwaFiAuEJ3Xg==",
       "requires": {
         "@reduxjs/toolkit": "^1.8.1",
         "@yext/search-core": "^2.6.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "generate-notices": "generate-license-file --input package.json --output THIRD-PARTY-NOTICES --overwrite"
   },
   "dependencies": {
-    "@yext/search-headless": "^2.6.0-beta.3",
+    "@yext/search-headless": "^2.6.0-beta.4",
     "use-sync-external-store": "^1.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/search-headless-react",
-  "version": "2.5.0-beta.3",
+  "version": "2.5.0-beta.4",
   "description": "The official React UI Bindings layer for Search Headless",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
The new beta version has the isPagination variable which upstream beta dependencies of search-headless-react require.

J=none
TEST=auto

ran `npm run test`